### PR TITLE
Fixed default floor value in Output Logic example of ICE 5

### DIFF
--- a/book/ICE/ICE5.md
+++ b/book/ICE/ICE5.md
@@ -137,7 +137,7 @@ with f_Q select
     o_floor <= <value> when s_floor1,
             ...
             ...
-            <value> when others; -- default is floor1
+            <value> when others; -- default is floor2
 ```
 
 - The entity declaration has been completed for you.

--- a/book/ICE/ICE6.md
+++ b/book/ICE/ICE6.md
@@ -88,14 +88,14 @@ end TDM4;
     it to your test bench's simulated clk
 - `i_reset` is an input signal which resets the TDM which sets the output to `i_D0`.
 - `i_D3` is the first of 4 data sets which are passed into the TDM.
-    Notice that it is a vector of `(k_width -1 downto 0)`. This means if
+    Notice that it is a vector of `(k_width - 1 downto 0)`. This means if
     `k_width` is 4 then `i_D3` is a 4-bit vector from 3 downto 0.
     `k_width` then allows the user to determine how big of a vector is going to be
     passed through. We will use 4 in this example, but if you were to
     use this with your seven segment decoder you could set it to 7.
 - `i_D2` is the second of 4 data sets which are passed into the TDM.
-- `i_D1` is the second of 4 data sets which are passed into the TDM.
-- `i_D0` is the second of 4 data sets which are passed into the TDM.
+- `i_D1` is the third of 4 data sets which are passed into the TDM.
+- `i_D0` is the fourth of 4 data sets which are passed into the TDM.
 - `o_data` represents the output of the TDM. At any point in time it
     will be one of `i_D3`, `i_D2`, `i_D1`, or `i_D0`.
 - `o_sel_n` is an output vector that tells the user which of the input


### PR DESCRIPTION
Default value listed in the Output Logic example of ICE 5 was given as floor1. floor2 is the correct default value in line with the rest of the ICE5 and Lab4.